### PR TITLE
fix bug in wikitext2structured in which "plaintext" and "text" are both used as keys

### DIFF
--- a/mwtext/about.py
+++ b/mwtext/about.py
@@ -1,5 +1,5 @@
 __name__ = "mwtext"
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "Aaron Halfaker"
 __author_email__ = "aaron.halfaker@gmail.com"
 __description__ = "A set of utilities for processing MediaWiki text."

--- a/mwtext/content_transformers/wikitext2structured.py
+++ b/mwtext/content_transformers/wikitext2structured.py
@@ -320,7 +320,7 @@ class Wikitext2Structured(ContentTransformer):
                     not parse_state["current_text"].isspace()
                 ):
                     paragraphs_local.append({
-                        "text": parse_state["current_text"],
+                        "plaintext": parse_state["current_text"],
                         "wikilinks": parse_state["current_wikilinks"],
                         "section_idx": parse_state["section_idx"],
                         "section_name": parse_state["section_name"]})


### PR DESCRIPTION
fixes a bug in which some paragraphs had the key "text" and others had the key "plaintext".  now they all have "plaintext"