### PR TITLE
additional filters for wikidata

### DIFF
--- a/mwtext/content_transformers/wikidata2words.py
+++ b/mwtext/content_transformers/wikidata2words.py
@@ -31,12 +31,20 @@ class Wikidata2Words(ContentTransformer):
         doc = json.loads(content)
         entity = mwbase.Entity.from_json(doc)
         claims_tuples = list(self._extract_property_values(entity))
+        if self.instanceof_nonzero_namespace(claims_tuples):
+            return None
         claims_tuples.sort(key=self.get_claim_pid_index)
         return list(chain(*claims_tuples))
 
     def get_claim_pid_index(self, claims_tuple):
         pid = claims_tuple[0]
         return self.pid_order_map.get(pid, len(self.pid_order_map))
+
+    def instanceof_nonzero_namespace(self, claims_tuples):
+        namespace_QIDs = ['Q4167836', 'Q11266439', 'Q4663903']
+        return any((claims_tuple[0] == 'P31' and
+                    claims_tuple[1] in namespace_QIDs)
+                   for claims_tuple in claims_tuples)
 
     @staticmethod
     def _extract_property_values(entity):

--- a/mwtext/filter_functions/wikidata_items_with_wikipedia_sitelinks.py
+++ b/mwtext/filter_functions/wikidata_items_with_wikipedia_sitelinks.py
@@ -10,13 +10,19 @@ def include(page, revision):
 
     item_doc = json.loads(revision.text)
     qid = item_doc.get('id', None)
+    redirect = item_doc.get('redirect')
     entity = mwbase.Entity.from_json(item_doc)
 
     # Has a Qid
     if qid is None:
         return False
 
+    # Redirects to other Wikidata item
+    if redirect is not None:
+        return False
+
     # Sitelinks to a Wikipedia of any language
-    return any((llink not in ('commonswiki', 'specieswiki') and
+    return any((llink not in ('commonswiki', 'specieswiki',
+                'metawiki', 'testwiki') and
                 llink.endswith("wiki"))
                for llink in entity.sitelinks)

--- a/mwtext/utilities/transform_content.py
+++ b/mwtext/utilities/transform_content.py
@@ -97,6 +97,8 @@ def transform_content(
                 continue
 
             transformed_doc = transformer.transform(revision.text)
+            if transformed_doc is None:
+                continue
             rev_doc = revision.to_json()
             rev_doc['page'] = page.to_json()
             rev_doc['page']['page_name'] = \


### PR DESCRIPTION
filters out wikidata items associated with pages in Wikipedia Category, Template, and Portal (eg: [Q3180](https://www.wikidata.org/wiki/Q3180))